### PR TITLE
feat: Add lru_cache decorator (#4)

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -23,7 +23,7 @@ async def inlay(ctx, url: str):
     async with ctx.channel.typing():
         site, url = process_site(url, sites)
         if url:
-            embed = process_url(url, site, direct=True)
+            embed = process_url(url, site.get("name", None), direct=True)
     if embed:
         await ctx.channel.send(content=embed)
     else:
@@ -38,7 +38,7 @@ if cfg["automatic"]:
             site, url = process_site(ctx.content, sites)
             if site and url:
                 async with ctx.channel.typing():
-                    embed = process_url(url, site)
+                    embed = process_url(url, site.get("name", None))
             if embed: 
                 await ctx.channel.send(content=embed)
 

--- a/util/inspect.py
+++ b/util/inspect.py
@@ -1,4 +1,5 @@
 from urllib.parse import urlsplit
+from functools import lru_cache
 import youtube_dl
 import logging
 import re
@@ -36,15 +37,16 @@ def process_site(msg, sites):
             
     return None, None
 
-def process_url(url, site, direct=False):
+@lru_cache(maxsize=None)
+def process_url(url, site_name, direct=False):
     try:
-        if direct and not site:
+        if direct and not site_name:
             return base(extract_info(url))
         else:
             info = extract_info(url)
             
-            if site["name"] in platforms.keys(): # There is a special handler for the URL 
-                embed = platforms[site["name"]](info)
+            if site_name in platforms.keys(): # There is a special handler for the URL 
+                embed = platforms[site_name](info)
             else:
                 embed = info["url"] # Attempt get key "URL"
 


### PR DESCRIPTION
This pr decorates `process_url` with [`lru_cache`](https://docs.python.org/3/library/functools.html#functools.lru_cache). Currently, there is no size limit to the cache.

Because dictionaries are not hashable, the parameters for `process_url` is changed from passing in the `site` dict to just getting value of `name` from `site` when invoking.

If the full `site` dict needs to be passed in to `process_url`, perhaps converting `site` to a `frozendict`, might be useful.

[https://stackoverflow.com/questions/6358481/using-functools-lru-cache-with-dictionary-arguments](https://stackoverflow.com/questions/6358481/using-functools-lru-cache-with-dictionary-arguments)